### PR TITLE
Streamlined workflow: single PR per issue, path validation, robust judge handling

### DIFF
--- a/tools/spec2pr/contracts/task.schema.json
+++ b/tools/spec2pr/contracts/task.schema.json
@@ -43,6 +43,11 @@
       "items": {"type": "string"},
       "description": "What not to do",
       "default": []
+    },
+    "independent": {
+      "type": "boolean",
+      "description": "If true, this task creates its own PR instead of being grouped with others",
+      "default": false
     }
   }
 }

--- a/tools/spec2pr/stages/publish.py
+++ b/tools/spec2pr/stages/publish.py
@@ -1,5 +1,7 @@
 """Publish stage - creates PRs or issues based on judgment."""
 
+import subprocess
+
 from adapters.github import (
     delete_branch_if_exists,
     create_branch,
@@ -9,6 +11,81 @@ from adapters.github import (
     create_pr,
     create_issue,
 )
+
+
+def publish_combined_pr(repo: str, spec: dict, accepted_tasks: list, issue_number: int) -> str:
+    """
+    Create a single PR for all accepted tasks.
+
+    Args:
+        repo: Repository in owner/repo format
+        spec: Original spec dict
+        accepted_tasks: List of {"task": task, "result": result, "verify": verify_result}
+        issue_number: Original spec issue number to close
+
+    Returns:
+        PR URL
+    """
+    branch_name = f"spec2pr/issue-{issue_number}"
+
+    # Clean up any existing remote branch from previous runs (keep local changes!)
+    subprocess.run(
+        ["git", "push", "origin", "--delete", branch_name],
+        capture_output=True,  # Don't fail if branch doesn't exist
+    )
+
+    # Create branch from current state (preserving task changes in working dir)
+    # First delete local branch if exists
+    subprocess.run(["git", "branch", "-D", branch_name], capture_output=True)
+    create_branch(branch_name)
+
+    # Commit all current changes (from all tasks)
+    all_files = []
+    task_summaries = []
+    for item in accepted_tasks:
+        task = item["task"]
+        result = item["result"]
+        verify = item["verify"]
+
+        files = result.get("files_modified", [])
+        all_files.extend(files)
+
+        status = "✅" if verify.get("passed", False) else "⚠️"
+        task_summaries.append(f"- [{status}] **{task['id']}**: {task['title']}")
+
+    # Single commit with all changes
+    commit_msg = f"spec2pr: {spec['title']}\n\nTasks completed:\n" + "\n".join(
+        f"- {item['task']['id']}: {item['task']['title']}" for item in accepted_tasks
+    )
+    commit_changes(commit_msg)
+
+    # Rebase on latest main
+    if not rebase_on_main():
+        import sys
+        print("Warning: Rebase on main failed (conflicts). PR may have merge conflicts.", file=sys.stderr)
+
+    push_branch(branch_name, force=True)
+
+    # Build PR body
+    body = f"""## Summary
+
+{spec['title']}
+
+Closes #{issue_number}
+
+## Tasks Completed
+
+{chr(10).join(task_summaries)}
+
+## Files Modified
+
+{', '.join(sorted(set(all_files))) if all_files else 'None'}
+
+---
+*This PR was created automatically by [spec2pr](https://github.com/andreikorchagin/spec2pr). Please review carefully before merging.*
+"""
+
+    return create_pr(repo, branch_name, f"spec2pr: {spec['title']}", body)
 
 
 def publish_pr(repo: str, task: dict, result: dict, issue_number: int) -> str:


### PR DESCRIPTION
## Summary

Fixes the cumulative PR problem and adds robustness improvements for the spec2pr pipeline.

Closes #11

## Changes

- **Single PR per issue**: Create one PR containing all accepted tasks instead of one PR per task
- **Path validation**: Fail fast in verify stage if files_allowlist contains hallucinated paths
- **Robust judge handling**: Gracefully handle malformed judge responses (missing verdict field)
- **Schema update**: Add independent field for future per-task PR option

## Test plan

- [ ] Trigger spec2pr on a test issue and verify only ONE PR is created
- [ ] Verify path validation catches invalid paths
- [ ] Verify malformed judge responses do not crash the pipeline

Generated with Claude Code